### PR TITLE
Fix Electron dev server port mismatch

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -93,7 +93,7 @@ Eine lokale Desktop-Anwendung für Agenturen und Freelancer zur professionellen 
    - Prisma für Datenbank-ORM
 
 3. **Electron-Konfiguration**:
-   - Port-Konflikt (5173 vs 5174 in electron.cjs)
+   - Port-Konflikt behoben – electron.cjs nutzt jetzt 5173
    - Fehlende IPC-Kommunikation zwischen Main und Renderer
 
 4. **Fehlende Funktionalitäten**:

--- a/electron.cjs
+++ b/electron.cjs
@@ -17,7 +17,7 @@ function createWindow() {
 
   // React-App laden
   const startUrl = isDev
-    ? 'http://localhost:5174'
+    ? 'http://localhost:5173'
     : `file://${path.join(__dirname, '../dist/index.html')}`
  
   mainWindow.loadURL(startUrl)


### PR DESCRIPTION
## Summary
- update dev server port in `electron.cjs` to match vite
- note resolved port conflict in docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68738c0c4f308324813c22b6eefa2f34