### PR TITLE
Start backend phase

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,22 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Backend Setup (Phase 2)
+
+Phase 2 introduces a simple Express API backed by SQLite via Prisma. To get started:
+
+1. Install dependencies (requires internet):
+   ```bash
+   npm install
+   ```
+2. Run Prisma migrations to create the database:
+   ```bash
+   npx prisma migrate dev --name init
+   ```
+3. Start the API server:
+   ```bash
+   npm run server
+   ```
+
+The server exposes basic CRUD endpoints under `/clients` as a starting point for database integration.

--- a/package.json
+++ b/package.json
@@ -15,11 +15,15 @@
     "electron": "electron .",
     "electron-dev": "concurrently \"npm run dev\" \"wait-on http://localhost:5173 && electron .\"",
     "build-electron": "npm run build && electron .",
-    "dist": "npm run build && electron-builder"
+    "dist": "npm run build && electron-builder",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "express": "^4.18.2",
+    "@prisma/client": "^5.12.0",
+    "sqlite3": "^5.1.6"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",
@@ -35,6 +39,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "vite": "^5.2.0",
-    "wait-on": "^7.2.0"
+    "wait-on": "^7.2.0",
+    "prisma": "^5.12.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,34 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Client {
+  id    Int     @id @default(autoincrement())
+  name  String
+  email String
+  phone String?
+  company String?
+  status String?
+  createdDate DateTime @default(now())
+  projects Project[]
+}
+
+model Project {
+  id          Int      @id @default(autoincrement())
+  name        String
+  clientId    Int
+  client      Client   @relation(fields: [clientId], references: [id])
+  status      String?
+  priority    String?
+  deadline    DateTime?
+  budget      Int?
+  progress    Int?
+  description String?
+  createdDate DateTime @default(now())
+  updatedDate DateTime @updatedAt
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(express.json());
+
+// Basic client CRUD endpoints
+app.get('/clients', async (req, res) => {
+  const clients = await prisma.client.findMany();
+  res.json(clients);
+});
+
+app.post('/clients', async (req, res) => {
+  const client = await prisma.client.create({ data: req.body });
+  res.json(client);
+});
+
+app.put('/clients/:id', async (req, res) => {
+  const { id } = req.params;
+  const client = await prisma.client.update({ where: { id: Number(id) }, data: req.body });
+  res.json(client);
+});
+
+app.delete('/clients/:id', async (req, res) => {
+  const { id } = req.params;
+  await prisma.client.delete({ where: { id: Number(id) } });
+  res.json({ success: true });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- set up simple Express server using Prisma
- add Prisma schema using SQLite
- add `.env` with sample database URL
- add new dependencies and server script to `package.json`
- document backend setup steps in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68738ddfba24832488eb23afb72d2b2e